### PR TITLE
VSync support for framebuffer device

### DIFF
--- a/xbmc/windowing/egl/EGLNativeType.h
+++ b/xbmc/windowing/egl/EGLNativeType.h
@@ -146,6 +146,12 @@ public:
     framebuffer */
   virtual bool  ShowWindow(bool show) = 0;
 
+/*! \brief Waits for VSYNC, if possible
+
+    This call is there to wait until a VSYNC event happens, so that buffers
+    can be swapped without tearing, if the kernel driver implements it */
+  virtual void  WaitVSync() {};
+
 protected:
   XBNativeDisplayType  m_nativeDisplay;
   XBNativeWindowType   m_nativeWindow;

--- a/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
+++ b/xbmc/windowing/egl/EGLNativeTypeAmlogic.h
@@ -46,6 +46,7 @@ public:
   virtual bool  GetPreferredResolution(RESOLUTION_INFO *res) const;
 
   virtual bool  ShowWindow(bool show);
+  virtual void  WaitVSync();
 
 protected:
   bool SetDisplayResolution(const char *resolution);
@@ -58,4 +59,5 @@ private:
   bool IsHdmiConnected() const;
 
   std::string m_framebuffer_name;
+  int         m_framebuffer_fd;
 };

--- a/xbmc/windowing/egl/EGLWrapper.cpp
+++ b/xbmc/windowing/egl/EGLWrapper.cpp
@@ -374,6 +374,7 @@ bool CEGLWrapper::SetVSync(EGLDisplay display, bool enable)
   // might fail so let caller decide if this is an error.
   status = eglSwapInterval(display, enable ? 1 : 0);
   CheckError();
+  m_vsync = (enable && m_result == EGL_SUCCESS);
   return status;
 }
 
@@ -381,6 +382,8 @@ void CEGLWrapper::SwapBuffers(EGLDisplay display, EGLSurface surface)
 {
   if ((display == EGL_NO_DISPLAY) || (surface == EGL_NO_SURFACE))
     return;
+  if (m_vsync)
+    m_nativeTypes->WaitVSync();
   eglSwapBuffers(display, surface);
 }
 

--- a/xbmc/windowing/egl/EGLWrapper.h
+++ b/xbmc/windowing/egl/EGLWrapper.h
@@ -72,4 +72,5 @@ private:
 
   CEGLNativeType *m_nativeTypes;
   EGLint         m_result;
+  bool           m_vsync;
 };


### PR DESCRIPTION
**Please do not merge this PR, as it is NOT needed starting with `2015-01-15-321cfb5a46`**

**Please do not merge this PR**, it is there to get the discussion rolling.

This is a first try at implementing VSync on top of the framebuffer device, using `FBIO_WAITFORVSYNC`, which is available starting with the 2015-01-15-321cfb5a46 release (as seen at https://github.com/codesnake/linux-amlogic/blob/master/drivers/amlogic/display/osd/osd_main.c#L526)

I'm gonna update this PR as I do more testing (if need be).
